### PR TITLE
Update plugin.xml

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -13,9 +13,8 @@
 
   <platform name="android">
     <preference name="WINDOW_BACKGROUND_COLOR" default="#ffffff" />
+    <hook type="after_prepare" src="scripts/apply-changes.js" />
+    <hook type="after_plugin_add" src="scripts/apply-changes.js" />
+    <hook type="after_plugin_install" src="scripts/apply-changes.js" />
   </platform>
-
-  <hook type="after_prepare" src="scripts/apply-changes.js" />
-  <hook type="after_plugin_add" src="scripts/apply-changes.js" />
-  <hook type="after_plugin_install" src="scripts/apply-changes.js" />
 </plugin>


### PR DESCRIPTION
define hook only for android platfrom is better. if in cordova app would have existed other platfrom like ios when we run cordova prepare for ios get error beacause hook can not find android platform folder if No Android platform has been added yet